### PR TITLE
fix: filter out environments without HSP endpoint

### DIFF
--- a/api/get-endpoints.js
+++ b/api/get-endpoints.js
@@ -2,6 +2,7 @@ const fetch = require('cross-fetch');
 
 const PLATFORM_ENDPOINT_NAME = 'mainEndpoint';
 const SEARCH_ENDPOINT_NAME = 'hostedSearchPagesEndpoint';
+const PRIMARY_REGION_TYPE = 'PRIMARY';
 
 const getRegionsListEndpoint = (environment) => `https://platform${environment}.cloud.coveo.com/rest/global/regions`;
 
@@ -12,15 +13,15 @@ const getCoveoAPIUrl = async (region, environment, endpoint) => {
     const regionListEndpoint = getRegionsListEndpoint(environment);
     const regionList = await (await fetch(regionListEndpoint)).json();
     if (!region) {
-        return regionList[0].hostedSearchPagesEndpoint;
+        return regionList[0][endpoint];
     }
     return regionList.find((regionInList) => regionInList.regionName === region)?.[endpoint]
         ?? (
             () => {
                 const availableRegions = regionList
-                    .filter((regionInList) => !!regionInList.hostedSearchPagesEndpoint)
+                    .filter((regionInList) => regionInList.regionType === PRIMARY_REGION_TYPE)
                     .map((regionInList) => regionInList.regionName);
-                throw new Error(`Region ${region} not found. Available regions for platform${environment} are ${availableRegions}`);
+                throw new Error(`Region ${region} not found. Available regions for ${environment} are ${availableRegions}`);
             })();
 };
 

--- a/api/get-endpoints.js
+++ b/api/get-endpoints.js
@@ -15,7 +15,13 @@ const getCoveoAPIUrl = async (region, environment, endpoint) => {
         return regionList[0].hostedSearchPagesEndpoint;
     }
     return regionList.find((regionInList) => regionInList.regionName === region)?.[endpoint]
-        ?? (() => { throw new Error(`Region ${region} not found. Available regions are ${regionList.map((regionInList) => regionInList.regionName)}`); })();
+        ?? (
+            () => {
+                const availableRegions = regionList
+                    .filter((regionInList) => !!regionInList.hostedSearchPagesEndpoint)
+                    .map((regionInList) => regionInList.regionName);
+                throw new Error(`Region ${region} not found. Available regions for platform${environment} are ${availableRegions}`);
+            })();
 };
 
 const getPushEndpoint = async (region, environment, organizationId, pageName) => `https://${await getCoveoAPIUrl(region, environment, SEARCH_ENDPOINT_NAME)}/pages/${organizationId}/${pageName}`;


### PR DESCRIPTION
[WORK-1153](https://coveord.atlassian.net/browse/WORK-1153)

@wmannard Found that there are some environments where not all regions are supported, making the error message incorrect.
This fixes it